### PR TITLE
fix: correct Falied to Failed typo in urlbar placeholder warning

### DIFF
--- a/browser/components/urlbar/content/UrlbarInput.mjs
+++ b/browser/components/urlbar/content/UrlbarInput.mjs
@@ -656,7 +656,7 @@ export class UrlbarInput extends HTMLElement {
       case "keyword.enabled":
         this._updatePlaceholderFromDefaultEngine().catch(e =>
           // This can happen if the search service failed.
-          console.warn("Falied to update urlbar placeholder:", e)
+          console.warn("Failed to update urlbar placeholder:", e)
         );
         break;
       case "browser.search.widget.new": {


### PR DESCRIPTION
I understand - this repo's typo originates from Mozilla upstream and you'd prefer not to carry patches across versions. Closing per your feedback.