### PR TITLE
Remove duplicate line from gkrust-features.mozbuild

### DIFF
--- a/toolkit/library/rust/gkrust-features.mozbuild
+++ b/toolkit/library/rust/gkrust-features.mozbuild
@@ -86,7 +86,6 @@ if CONFIG["MOZ_JXL"]:
 if CONFIG["MOZ_BUILD_APP"] == "browser" and CONFIG["OS_ARCH"] == "WINNT":
     gkrust_features += ["shell_windows"]
 
-gkrust_features += ["glean_disable_upload"]
 
 # This must remain last.
 gkrust_features = ["gkrust-shared/%s" % f for f in gkrust_features]


### PR DESCRIPTION
Remove duplicate line as it already exists on line 61, which causes win-153 build to fail early until one of the two lines is removed.